### PR TITLE
Open About:Blank manually option

### DIFF
--- a/src/data/settings.js
+++ b/src/data/settings.js
@@ -39,13 +39,23 @@ export const privacyConfig = ({ options, updateOption, openPanic }) => ({
     disabled: !options.tabName || options.tabName == meta[0].value.tabName,
   },
   3: {
-    name: 'Open in AB',
-    desc: 'This will open the site into an about:blank tab. Make sure popups are enabled.',
-    value: options.aboutBlank,
+    name: 'Open about:blank on startup',
+    desc: 'When enabled, the about:blank tab opens automatically when you visit.',
+    value:
+      options.aboutBlankAutoOpen === true ||
+      (options.aboutBlank && options.aboutBlankAutoOpen !== false),
     type: 'switch',
-    action: (b) => setTimeout(() => updateOption({ aboutBlank: b }), 100),
+    action: (b) => setTimeout(() => updateOption({ aboutBlankAutoOpen: b }), 100),
   },
   4: {
+    name: 'Open manually',
+    desc: 'Open the about:blank tab now.',
+    value: 'Open manually',
+    type: 'button',
+    action: () =>
+      import('/src/utils/utils.js').then(({ openAboutBlankPopup }) => openAboutBlankPopup(true)),
+  },
+  5: {
     name: 'Panic Key',
     desc: 'Enable or disable the panic key option.',
     value: !!options.panicToggleEnabled,
@@ -57,7 +67,7 @@ export const privacyConfig = ({ options, updateOption, openPanic }) => ({
       }, 100);
     },
   },
-  5: {
+  6: {
     name: 'Panic Shortcut',
     desc: 'Set a keybind/shortcut that redirects you to a page when pressed.',
     value: 'Set Key',

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -70,6 +70,48 @@ export const panic = () => {
   }
 };
 
+/**
+ * Opens the about:blank popup with an iframe pointing to the current proxy URL.
+ * Syncs title/icon from localStorage.options in the popup.
+ * @param {boolean} redirectCurrentTab - If true, redirect this tab to google.com after opening (default true).
+ * @returns {boolean} - True if popup was opened, false if blocked.
+ */
+export const openAboutBlankPopup = (redirectCurrentTab = true) => {
+  const w = open('about:blank');
+  if (!w || w.closed) {
+    alert('Popup was blocked. Allow popups for this site and try again.');
+    return false;
+  }
+  const win = w.window;
+  const d = win.document;
+  const f = d.createElement('iframe');
+
+  Object.assign(f, { src: location.href });
+  Object.assign(f.style, { width: '100%', height: '100%', border: 'none' });
+  Object.assign(d.body.style, { margin: 0, height: '100vh' });
+  d.documentElement.style.height = '100%';
+  d.head.appendChild(Object.assign(document.createElement('link'), { rel: 'icon', href: '' }));
+  d.body.append(f);
+  const s = d.createElement('script');
+  s.textContent = `
+    const d = document;
+    setInterval(() => {
+      const op = JSON.parse(localStorage.getItem('options') || '{}');
+      d.title = op.tabName || '';
+      let icon = d.querySelector("link[rel~='icon']");
+      if (!icon) {
+        icon = d.createElement('link');
+        icon.rel = 'icon';
+        d.head.appendChild(icon);
+      }
+      icon.href = op.tabIcon || '';
+    }, 800);
+  `;
+  d.head.appendChild(s);
+  if (redirectCurrentTab) location.href = 'https://google.com';
+  return true;
+};
+
 export const check = (() => {
   const op = JSON.parse(localStorage.options || '{}');
   !op.version && localStorage.setItem('options', JSON.stringify({ version: pkg.version }));
@@ -79,40 +121,10 @@ export const check = (() => {
       e.returnValue = '';
     });
   }
-  if (window.top === window.self && op.aboutBlank) {
-    const w = open('about:blank');
-    if (!w || w.closed) {
-      alert('Please enable popups to continue.');
-      location.href = 'https://google.com';
-    } else {
-      const win = w.window,
-        d = win.document,
-        f = d.createElement('iframe');
-
-      Object.assign(f, { src: location.href });
-      Object.assign(f.style, { width: '100%', height: '100%', border: 'none' });
-      Object.assign(d.body.style, { margin: 0, height: '100vh' });
-      d.documentElement.style.height = '100%';
-      d.head.appendChild(Object.assign(document.createElement('link'), { rel: 'icon', href: '' }));
-      d.body.append(f);
-      const s = d.createElement('script');
-      s.textContent = `
-        const d = document;
-        setInterval(() => {
-          const op = JSON.parse(localStorage.getItem('options') || '{}');
-          d.title = op.tabName || '';
-          let icon = d.querySelector("link[rel~='icon']");
-          if (!icon) {
-            icon = d.createElement('link');
-            icon.rel = 'icon';
-            d.head.appendChild(icon);
-          }
-          icon.href = op.tabIcon || '';
-        }, 800);
-      `;
-      d.head.appendChild(s);
-      location.href = 'https://google.com';
-    }
+  const openOnStartup =
+    op.aboutBlankAutoOpen === true || (op.aboutBlank && op.aboutBlankAutoOpen !== false);
+  if (window.top === window.self && openOnStartup) {
+    openAboutBlankPopup(true);
     history.replaceState(null, '', '/');
   }
 


### PR DESCRIPTION
Adds an "Open manually" button so users can open the about:blank tab on demand. A new "Open on startup" toggle (default on) lets them turn off auto-open and use the button instead.